### PR TITLE
Add release notes generator and Crane 1.3.2 release notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .jekyll-cache
 .jekyll-metadata
 vendor
+rng/config.yml

--- a/release_notes/Crane/release-1.3.2.md
+++ b/release_notes/Crane/release-1.3.2.md
@@ -1,1 +1,140 @@
 # Crane Release Notes: v1.3.2
+
+## Repo: mig-ui
+
+```
+1018a9c Revert "UI changes to support removal of remote watches (#1014)" (#1063)
+9fd30e2 move to dayjs from moment (#1056)
+0787f8e Fix copy oc command for resources in debug dropdown (#1050)
+a174e8f Merge branch 'fix-oc-command' of https://github.com/ibolton336/mig-ui into release-1.3.2
+bbf1d06 Update webpack-dev-server (#1051)
+4f10d1b Update cert error with suggested copy (#1047)
+561172c Merge branch 'master' into fix-oc-command
+4d10d26 lint fixes
+1bf3edb Update webpack-dev-server (#1051)
+b21e6ba revert yarn.lock
+91db6ff finish cleaning up UX
+cd6ef72 wip
+1539706 Update cert error with suggested copy (#1047)
+e344918 Revert "Skip MigPlan readiness check at PV discovery (#1034)" (#1046)
+9b4d80b Cert error copy update (#1044)
+8d6f707 Cert error copy update (#1044)
+156c9b5 Reduce bundle size by tree shaking, matching lodash version, & adding compression (#1021)
+c35f58e Reduce bundle size by tree shaking, matching lodash version, & adding compression (#1021)
+8028410 fix miganalytics flashing when updating migmigration list (#1028)
+2f037fd Move login OAuth token handling to backend (#967)
+7784b56 Use nodejs image/update to nodejs 12 (#1031)
+2909bb4 Move login OAuth token handling to backend (#967)
+88063ea fix miganalytics flashing when updating migmigration list (#1028)
+feab7b3 Skip MigPlan readiness check at PV discovery (#1034)
+ed433f5 UI changes to support removal of remote watches (#1014)
+6bd74a6 Use nodejs image/update to nodejs 12 (#1031)
+```
+
+## Repo: mig-controller
+
+```
+089e7677 Filter velero pod list on currently-running (non-terminating) pods
+09044323 Fix discovery debug tree filtering on PVBs/PVRs (#723)
+d8f27843 Use ubi8/go-toolset:1.14.7 to avoid ratelimit build failures (#798)
+d6ebd79b Bug 1894822: Fix flipped src/dest pods (#797)
+9d07f267 Fix PodVolumeBackup & PodVolumeRestore not updating in the discovery inventory correctly. fixes #724
+```
+
+## Repo: mig-operator
+
+```
+0bf39e6 Update 1.3.2 CSV (#480)
+cbbfcc7 Update to account for SA name change from 'mig' to  'migration-controller'
+c286ecb Added demo links
+190b464 (temporarily) pin community.kubernetes to fix operator_sdk.util (#475)
+bb45093 Rollback on demand update (#473)
+c4a3b5b Update Cluster, Plan, Storage CRD to include "refresh" spec field. Move StorageClasses cache to MigPlan. (#427)
+6674c25 Add table of contents to README.md (#472)
+dc49711 update sprint release docs (#471)
+e166cd2 Pause for Quay (#469)
+dbabcbb Front page README.md formatting pass, move CORS instructions off front page (#470)
+9ae5e7c Add instructions to export from bundle to appregistry format (#468)
+f88a399 Update hacking.md with opm instructions (#467)
+109ea08 sprint-build playbook fixes (#466)
+0783f3a Update CatalogSource to be created in marketplace ns (#465)
+85b2678 Add playook to release a sprint build upstream (#459)
+0a62f62 checkout files automatically (#462)
+bc592e6 add 1.3.1 to skips (#460)
+```
+
+## Repo: velero
+
+```
+4c9131f1 Use restic release branch for build (#77)
+8bd8ce87 1.4.3 rebase (#76)
+584d0734 Merge pull request #75 from sseago/crd-resource-fix-upstream
+d52b1394 restore proper lowercase/plural CRD resource (#2949)
+c20e33ff version string bump to 1.4.2 (#73)
+a0b9fac5 Merge pull request #71 from dymurray/vendorUpdate
+4b557f2a Include vendor and update Dockerfiles to use vendor
+```
+
+## Repo: openshift-velero-plugin
+
+```
+84da4e5 Bug 1890704: Return errors from image copy failures (#63)
+```
+
+## Repo: velero-plugin-for-microsoft-azure
+
+```
+cf82893 vendor files for azure plugin
+2a88b4f Wait for snapshot to be ready before restoring
+df2536c Update Dockerfile.ubi for go modules
+6cbe641 adding Dockerfile.ubi
+0eb06da Merge pull request #76 from ashish-amarnath/v1.1.1
+602eceb changelogs and compatibility matrix update
+6d94db5 Add workflow to auto-assign reviewers (#69)
+7da5881 Merge pull request #66 from ashish-amarnath/node-selector-doc
+6777e15 📖 document node selector for linux
+7f692d4 Merge pull request #59 from sabvente/main
+1ba9caa Merge pull request #60 from cfreemoser/bugfix/typo_in_readme
+be974f1 Remove extra indentation from README.
+8a79d19 Replaces SUBSCRIPTION_ID with AZURE_SUBSCRIPTION_ID
+e088aa5 Merge pull request #58 from carlisia/c-insensitive-language
+46068b3 Merge pull request #58 from carlisia/c-insensitive-language
+b3a7bf1 Address insensitive language
+55f3ba1 Merge pull request #52 from stephanwehr/support-incremental-snapshots
+3d038eb add support for incremental snapshots of Azure disks
+15b36f1 Merge pull request #51 from skriss/aad-pod-identity
+c22efaf support aad-pod-identity and certificate auth
+46e5099 Merge pull request #50 from ashish-amarnath/remove-travis
+4689036 remove travis config
+15173a4 rename gh actions add build status badge
+f165749 Merge pull request #44 from ashish-amarnath/github-actions
+c90ab91 github actions
+507fdef update build and Dockerfile to use go modules
+f3a2ca9 Merge pull request #43 from ashish-amarnath/go-modules
+8c879fb update build and Dockerfile to use go modules
+0e1ac19 remove vendor dir and Gopkg.lock and Gopkg.toml
+839052c generate go.mod and go.sum
+a31c98b remove changelog files that have already been released (#49)
+```
+
+## Repo: velero-plugin-for-aws
+
+**NO CHANGES**
+
+## Repo: velero-plugin-for-gcp
+
+**NO CHANGES**
+
+## Repo: restic
+
+**NO CHANGES**
+
+## Repo: hook-runner
+
+**NO CHANGES**
+
+## Repo: must-gather
+
+```
+ce3a497 Added pprof payload collection scripts (#7)
+```

--- a/release_notes/Crane/release-1.3.2.md
+++ b/release_notes/Crane/release-1.3.2.md
@@ -1,0 +1,1 @@
+# Crane Release Notes: v1.3.2

--- a/rng/README.md
+++ b/rng/README.md
@@ -1,0 +1,27 @@
+# Konveyor Release Notes Generator
+
+**Requires `git` in your PATH**
+
+Ensure you have copied your desired config to config.yml, which the ansible
+will look for. The ansible is generic in that it expects a specific data structure
+to the config, but separate configs can be written for different projects.
+The ansible will iterate the repos, checkout the projects to a temporary location,
+run a `git log` to produce a commit log for that repo, and append it to a release
+notes file currently found at `../release_notes/<PROJECT>/release-<VERSION>.md`.
+
+Example prep:
+
+`cp crane.config.yml.example config.yml`
+
+> NOTE: At least for Crane (MTC),  due to the way we've done our branches with
+> our forks, not all of our repos contain the same branching format.
+
+It's likely you'll need to tweak the config a bit for each release. In particular,
+you will need to flip the `has_changes` setting to `true` or `false`. Many of
+the Crane repos do not change between releases, hence the setting.
+
+After you're happy with the configuration, can be run with the `run.sh` script,
+no args necessary.
+
+Once the script finishes, add and commit the newly output release notes file,
+and submit a PR to the konveyor site!

--- a/rng/crane.config.yml.example
+++ b/rng/crane.config.yml.example
@@ -1,0 +1,1 @@
+release_version: 1.3.2

--- a/rng/crane.config.yml.example
+++ b/rng/crane.config.yml.example
@@ -6,57 +6,57 @@ output_file: "{{ output_dir }}/release-{{ new_release_version }}.md"
 
 repos:
 - name: mig-ui
-  url: "https://github.com/konveyor/mig-ui.git"
+  url: "git@github.com:/konveyor/mig-ui.git"
   nrv: "release-{{ new_release_version }}"
   lrv: "release-{{ last_release_version}}"
   has_changes: true
 - name: mig-controller
-  url: "https://github.com/konveyor/mig-controller.git"
+  url: "git@github.com:/konveyor/mig-controller.git"
   nrv: "release-{{ new_release_version }}"
   lrv: "release-{{ last_release_version}}"
   has_changes: true
 - name: mig-operator
-  url: "https://github.com/konveyor/mig-operator.git"
+  url: "git@github.com:/konveyor/mig-operator.git"
   nrv: "release-{{ new_release_version }}"
   lrv: "release-{{ last_release_version}}"
   has_changes: true
 - name: velero
-  url: "https://github.com/konveyor/velero.git"
+  url: "git@github.com:/konveyor/velero.git"
   nrv: "konveyor-1.4.3"
   lrv: "konveyor-1.4.2"
   has_changes: true
 - name: openshift-velero-plugin
-  url: "https://github.com/konveyor/opensihft-velero-plugin.git"
+  url: "git@github.com:/konveyor/openshift-velero-plugin.git"
   nrv: "release-{{ new_release_version }}"
   lrv: "release-{{ last_release_version}}"
   has_changes: true
 - name: velero-plugin-for-microsoft-azure
-  url: "https://github.com/konveyor/velero-plugin-for-microsoft-azure.git"
+  url: "git@github.com:/konveyor/velero-plugin-for-microsoft-azure.git"
   nrv: "konveyor-1.1.1"
   lrv: "konveyor-1.1.0"
   has_changes: true
 - name: velero-plugin-for-aws
-  url: "https://github.com/konveyor/velero-plugin-for-aws.git"
+  url: "git@github.com:/konveyor/velero-plugin-for-aws.git"
   nrv: "konveyor-1.1.0"
   lrv: "konveyor-1.0.1"
   has_changes: false
 - name: velero-plugin-for-gcp
-  url: "https://github.com/konveyor/velero-plugin-for-gcp.git"
+  url: "git@github.com:/konveyor/velero-plugin-for-gcp.git"
   nrv: "konveyor-1.1.0"
   lrv: "konveyor-1.0.1"
   has_changes: false
 - name: restic
-  url: "https://github.com/konveyor/resitc.git"
+  url: "git@github.com:/konveyor/restic.git"
   nrv: "konveyor-v0.9.6"
   lrv: "fusor-v0.9.5"
   has_changes: false
 - name: hook-runner
-  url: "https://github.com/konveyor/hook-runner.git"
+  url: "git@github.com:/konveyor/hook-runner.git"
   nrv: "release-{{ new_release_version }}"
   lrv: "release-{{ last_release_version }}"
   has_changes: false
 - name: must-gather
-  url: "https://github.com/konveyor/must-gather.git"
+  url: "git@github.com:/konveyor/must-gather.git"
   nrv: "release-{{ new_release_version }}"
   lrv: "release-{{ last_release_version }}"
   has_changes: true

--- a/rng/crane.config.yml.example
+++ b/rng/crane.config.yml.example
@@ -1,1 +1,62 @@
-release_version: 1.3.2
+project_name: Crane
+new_release_version: 1.3.2
+last_release_version: 1.3.1
+output_dir: "{{ root_dir }}/{{ project_name }}"
+output_file: "{{ output_dir }}/release-{{ new_release_version }}.md"
+
+repos:
+- name: mig-ui
+  url: "https://github.com/konveyor/mig-ui.git"
+  nrv: "release-{{ new_release_version }}"
+  lrv: "release-{{ last_release_version}}"
+  has_changes: true
+- name: mig-controller
+  url: "https://github.com/konveyor/mig-controller.git"
+  nrv: "release-{{ new_release_version }}"
+  lrv: "release-{{ last_release_version}}"
+  has_changes: true
+- name: mig-operator
+  url: "https://github.com/konveyor/mig-operator.git"
+  nrv: "release-{{ new_release_version }}"
+  lrv: "release-{{ last_release_version}}"
+  has_changes: true
+- name: velero
+  url: "https://github.com/konveyor/velero.git"
+  nrv: "konveyor-1.4.3"
+  lrv: "konveyor-1.4.2"
+  has_changes: true
+- name: openshift-velero-plugin
+  url: "https://github.com/konveyor/opensihft-velero-plugin.git"
+  nrv: "release-{{ new_release_version }}"
+  lrv: "release-{{ last_release_version}}"
+  has_changes: true
+- name: velero-plugin-for-microsoft-azure
+  url: "https://github.com/konveyor/velero-plugin-for-microsoft-azure.git"
+  nrv: "konveyor-1.1.1"
+  lrv: "konveyor-1.1.0"
+  has_changes: true
+- name: velero-plugin-for-aws
+  url: "https://github.com/konveyor/velero-plugin-for-aws.git"
+  nrv: "konveyor-1.1.0"
+  lrv: "konveyor-1.0.1"
+  has_changes: false
+- name: velero-plugin-for-gcp
+  url: "https://github.com/konveyor/velero-plugin-for-gcp.git"
+  nrv: "konveyor-1.1.0"
+  lrv: "konveyor-1.0.1"
+  has_changes: false
+- name: restic
+  url: "https://github.com/konveyor/resitc.git"
+  nrv: "konveyor-v0.9.6"
+  lrv: "fusor-v0.9.5"
+  has_changes: false
+- name: hook-runner
+  url: "https://github.com/konveyor/hook-runner.git"
+  nrv: "release-{{ new_release_version }}"
+  lrv: "release-{{ last_release_version }}"
+  has_changes: false
+- name: must-gather
+  url: "https://github.com/konveyor/must-gather.git"
+  nrv: "release-{{ new_release_version }}"
+  lrv: "release-{{ last_release_version }}"
+  has_changes: true

--- a/rng/main.yml
+++ b/rng/main.yml
@@ -1,0 +1,4 @@
+---
+- hosts: localhost
+  roles:
+    - konveyor_rng

--- a/rng/roles/konveyor_rng/.travis.yml
+++ b/rng/roles/konveyor_rng/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/rng/roles/konveyor_rng/README.md
+++ b/rng/roles/konveyor_rng/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/rng/roles/konveyor_rng/defaults/main.yml
+++ b/rng/roles/konveyor_rng/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for konveyor_rng

--- a/rng/roles/konveyor_rng/handlers/main.yml
+++ b/rng/roles/konveyor_rng/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for konveyor_rng

--- a/rng/roles/konveyor_rng/meta/main.yml
+++ b/rng/roles/konveyor_rng/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/rng/roles/konveyor_rng/tasks/append_repo_notes.yml
+++ b/rng/roles/konveyor_rng/tasks/append_repo_notes.yml
@@ -1,12 +1,33 @@
 ---
-- name: Print repo name
-  debug:
-    msg: "Working on repo {{ item.name }}"
+- name: Set repo checkout dir and notes to append file
+  set_fact:
+    repo_dir: "{{ tmp.path }}/{{ item.name }}"
+    notes_to_append_f: "{{ tmp.path }}/notes-to-append.md"
 
-- debug:
-    msg: "Has changes"
+- name: Handle changes
+  block:
+  - name: "Checkout {{ item.name }}"
+    git:
+      repo: "{{ item.url }}"
+      dest: "{{ repo_dir }}"
+
+  - name: Register commit diff
+    shell: "git log --oneline origin/{{ item.lrv }}..origin/{{ item.nrv }}"
+    args:
+      chdir: "{{ repo_dir }}"
+    register: commit_diff
+
+  - name: Render notes to append tempfile
+    template:
+      src: notes-to-append.md.j2
+      dest: "{{ notes_to_append_f }}"
   when: item.has_changes
 
-- debug:
-    msg: "No changes"
+- name: Handle no changes
+  template:
+    src: notes-to-append-no-changes.md.j2
+    dest: "{{ notes_to_append_f }}"
   when: not item.has_changes
+
+- name: Append notes to output notes
+  shell: "cat {{ notes_to_append_f }} >> {{ output_file }}"

--- a/rng/roles/konveyor_rng/tasks/append_repo_notes.yml
+++ b/rng/roles/konveyor_rng/tasks/append_repo_notes.yml
@@ -1,0 +1,12 @@
+---
+- name: Print repo name
+  debug:
+    msg: "Working on repo {{ item.name }}"
+
+- debug:
+    msg: "Has changes"
+  when: item.has_changes
+
+- debug:
+    msg: "No changes"
+  when: not item.has_changes

--- a/rng/roles/konveyor_rng/tasks/main.yml
+++ b/rng/roles/konveyor_rng/tasks/main.yml
@@ -1,2 +1,15 @@
 ---
-# tasks file for konveyor_rng
+
+- name: Ensure release notes directory exists
+  file:
+    path: "{{ output_dir }}"
+    state: directory
+
+- name: Initialize notes
+  template:
+    src: init-release-notes.md.j2
+    dest: "{{ output_file }}"
+
+#- name: Append repo notes
+  #include_tasks: append_repo_notes.yml
+  #loop: "{{ repos }}

--- a/rng/roles/konveyor_rng/tasks/main.yml
+++ b/rng/roles/konveyor_rng/tasks/main.yml
@@ -21,3 +21,8 @@
 - name: Append repo notes
   include_tasks: append_repo_notes.yml
   loop: "{{ repos }}"
+
+- name: Cleanup temporary dir
+  file:
+    path: "{{ tmp.path }}"
+    state: absent

--- a/rng/roles/konveyor_rng/tasks/main.yml
+++ b/rng/roles/konveyor_rng/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+# tasks file for konveyor_rng

--- a/rng/roles/konveyor_rng/tasks/main.yml
+++ b/rng/roles/konveyor_rng/tasks/main.yml
@@ -10,6 +10,14 @@
     src: init-release-notes.md.j2
     dest: "{{ output_file }}"
 
-#- name: Append repo notes
-  #include_tasks: append_repo_notes.yml
-  #loop: "{{ repos }}
+- name: Create and register working temp dir
+  tempfile:
+    state: directory
+  register: tmp
+
+- debug:
+    msg: "Tempfile dir: {{ tmp.path }}"
+
+- name: Append repo notes
+  include_tasks: append_repo_notes.yml
+  loop: "{{ repos }}"

--- a/rng/roles/konveyor_rng/templates/init-release-notes.md.j2
+++ b/rng/roles/konveyor_rng/templates/init-release-notes.md.j2
@@ -1,0 +1,1 @@
+# {{ project_name }} Release Notes: v{{ new_release_version}}

--- a/rng/roles/konveyor_rng/templates/notes-to-append-no-changes.md.j2
+++ b/rng/roles/konveyor_rng/templates/notes-to-append-no-changes.md.j2
@@ -1,0 +1,4 @@
+
+## Repo: {{ item.name }}
+
+**NO CHANGES**

--- a/rng/roles/konveyor_rng/templates/notes-to-append.md.j2
+++ b/rng/roles/konveyor_rng/templates/notes-to-append.md.j2
@@ -1,0 +1,6 @@
+
+## Repo: {{ item.name }}
+
+```
+{{ commit_diff.stdout}}
+```

--- a/rng/roles/konveyor_rng/tests/inventory
+++ b/rng/roles/konveyor_rng/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/rng/roles/konveyor_rng/tests/test.yml
+++ b/rng/roles/konveyor_rng/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - konveyor_rng

--- a/rng/roles/konveyor_rng/vars/main.yml
+++ b/rng/roles/konveyor_rng/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for konveyor_rng

--- a/rng/run.sh
+++ b/rng/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/rng/run.sh
+++ b/rng/run.sh
@@ -1,2 +1,7 @@
 #!/bin/bash
 _dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+ansible-playbook \
+  -eroot_dir=$_dir/../release_notes \
+  -e@$_dir/config.yml \
+  $_dir/main.yml


### PR DESCRIPTION
Adds Ansible scripts to generate release notes for konveyor projects. It's written generically so another config could be written for MTV and MTA and they'd end up in the right place. I'm submitting this here with the expectation we probably want these to end up on the konveyor site, so these are output to a markdown file in the project automatically, organized by project.

See the [`release_notes/Crane/release-1.3.2.md`](https://github.com/konveyor/konveyor.github.io/pull/10/files?short_path=7f9942e#diff-7f9942ec4de663c31870778fc99394ed72a93478ffbeff09fb2f95f9dbbc6855) file for an example output (these are the 1.3.2 MTC release notes).