### PR TITLE
Update links to konveyor.io, cont'd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-This repository holds the code that generates the [Konveyor Project's web page](https://konveyor.github.io/).
+This repository holds the code that generates the [Konveyor Project's web page](https://konveyor.io/).
 
 For more information you should read the [GitHub Pages Guide to Using Jekyll](https://help.github.com/en/github/working-with-github-pages/setting-up-a-github-pages-site-with-jekyll). It's really quiet easy to contribute.

--- a/index.md
+++ b/index.md
@@ -23,13 +23,13 @@ The Konveyor Community is working on tools in many areas. Here is a quick overvi
 
 If you have a tool you'd like to contribute please start a new thread in the [google group](https://groups.google.com/forum/#!forum/konveyorio).
 
-![crane logo](https://github.com/konveyor/konveyor.github.io/raw/master/images/crane-logo-lightbg.png)
+![crane logo](https://konveyor.io/raw/master/images/crane-logo-lightbg.png)
 
 ![crane](https://konveyor.io/images/Konveyor_Diagram_mig-operator.png)
 
 Crane allows users to discover namespaces on source clusters and migrate the objects and their persistent volumes to a destination cluster.
 
-![fork logo](https://github.com/konveyor/konveyor.github.io/raw/master/images/forklift-logo-lightbg.png)
+![fork logo](https://konveyor.io/raw/master/images/forklift-logo-lightbg.png)
 
 ![forklift](https://konveyor.io/images/Konveyor_Diagram_virt-operator.png)
 


### PR DESCRIPTION
This PR is a follow-up to #11 to replace missed occurrences of `konveyor.github.io`.