### PR TITLE
Add link to doc source code in published site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# konveyor.github.io
-Documentation for Konveyor projects
+# Overview
+This repository contains documentation for projects under [Konveyor.io](http://konveyor.io)
+* Leverages [Hugo](https://gohugo.io/)
+* Is served at: [https://konveyor.github.io/](https://konveyor.github.io/)
+    * Assets are built and served from the branch [gh-pages](https://github.com/konveyor/konveyor.github.io/tree/gh-pages)
+
+# Getting Started, how to run locally
+1. Fork or Clone the repository, ensure you check out the configured [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules)
+    * Example:
+
+        ``` git clone https://github.com/konveyor/konveyor.github.io.git --recursive```
+            
+        * We are using the ```--recursive`` command line flag to automatically clone a few themes which Hugo will use.  These are leveraging [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) 
+2. ```cd konveyor.github.io```
+3. ```hugo server -D```
+    * Run the hugo server locally, building posts that may be in 'draft'
+4. Visit http://localhost:1313/ in your web browser
+
+# How changes get published to 'production'
+
+All changes which merge to 'main' will [trigger a GitHub Action](https://github.com/konveyor/konveyor.github.io/actions) to run that builds the hugo assets and publishes to the [gh-pages branch](https://github.com/konveyor/konveyor.github.io/tree/gh-pages) 
+
+The URL,[https://konveyor.github.io/](https://konveyor.github.io/) is configured to serve the web assets from the [gh-pages branch](https://github.com/konveyor/konveyor.github.io/tree/gh-pages)  

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,1 +1,2 @@
 <a id="logo" href='{{ (cond (and (ne .Site.Params.landingPageURL nil) (.Site.IsMultiLingual)) .Site.Params.landingPageURL "/") }}'><img src="/images/konveyor_logo.png"></img></a>
+<a href="https://github.com/konveyor/konveyor.github.io"> Documentation source code</a>


### PR DESCRIPTION
Also added instructions in README for getting started to run local

Example of the hyperlink 'Documentation Source Code' which will render under the logo on the search panel.

<img width="1866" alt="Screen Shot 2022-05-27 at 1 07 31 PM" src="https://user-images.githubusercontent.com/206875/170758394-bd0c921e-d680-4b13-83b7-cd9eb7a28f10.png">
