### PR TITLE
:bug: Update gh-pages.yml

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,15 @@ jobs:
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+          
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
 
+      - name: Install PostCSS dependencies
+        run: npm install
+        
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:


### PR DESCRIPTION
fix postcss error in page deployment. Recent PRs have been failing with th eerror message

```
Error: error building site: POSTCSS: failed to transform "/scss/main.css" (text/css). You need to install PostCSS. See https://gohugo.io/functions/css/postcss/: binary with name "postcss" not found using npx
Error: Process completed with exit code 1.
```

This PR is an attempt to fix the issue 