### PR TITLE
fix: link to slack channel

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,11 +6,11 @@
             <li><a href="https://www.linuxfoundation.org/legal/trademark-usage" target="_blank">Trademark</a></li>
         </ul>
         <ul class="footer-links">
-            <li><a href="https://twitter.com/Konveyor_io" target="_blank"><i class="fa-brands fa-x-twitter"></i></a></li>
-            <li><a href="https://www.youtube.com/channel/UCQ3pW3gSBeCy0tj1J0ub2bw" target="_blank"><i class="fa-brands fa-youtube"></i></a></li>
-            <li><a href="https://www.linkedin.com/company/konveyor-community/?viewAsMember=true" target="_blank"><i class="fa-brands fa-linkedin"></i></a></li>
-            <li><a href="https://kubernetes.slack.com/archives/CR85S82A2" target="_blank"><i class="fa-brands fa-slack"></i></a></li>
-            <li><a href="https://github.com/konveyor" target="_blank"><i class="fa-brands fa-github"></i></a></li>
+            <li><a href="https://twitter.com/Konveyor_io" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-x-twitter"></i></a></li>
+            <li><a href="https://www.youtube.com/channel/UCQ3pW3gSBeCy0tj1J0ub2bw" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-youtube"></i></a></li>
+            <li><a href="https://www.linkedin.com/company/konveyor-community/?viewAsMember=true" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-linkedin"></i></a></li>
+            <li><a href="https://kubernetes.slack.com/archives/CR85S82A2" target="_blank" rel="noopener noreferrer" aria-label="Join Konveyor Slack channel"><i class="fa-brands fa-slack"></i></a></li>
+            <li><a href="https://github.com/konveyor" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-github"></i></a></li>
         </ul>
     </div>
     <div class="footer-inner-bottom">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -9,7 +9,7 @@
             <li><a href="https://twitter.com/Konveyor_io" target="_blank"><i class="fa-brands fa-x-twitter"></i></a></li>
             <li><a href="https://www.youtube.com/channel/UCQ3pW3gSBeCy0tj1J0ub2bw" target="_blank"><i class="fa-brands fa-youtube"></i></a></li>
             <li><a href="https://www.linkedin.com/company/konveyor-community/?viewAsMember=true" target="_blank"><i class="fa-brands fa-linkedin"></i></a></li>
-            <li><a href="https://www.konveyor.io/slack/" target="_blank"><i class="fa-brands fa-slack"></i></a></li>
+            <li><a href="https://kubernetes.slack.com/archives/CR85S82A2" target="_blank"><i class="fa-brands fa-slack"></i></a></li>
             <li><a href="https://github.com/konveyor" target="_blank"><i class="fa-brands fa-github"></i></a></li>
         </ul>
     </div>


### PR DESCRIPTION
This PR fixes the #70 issue using the default slack channel for this community as it is described in the main page of the GitHub organization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the community Slack link in the site footer to point to the Kubernetes Slack channel, ensuring visitors are directed to the project's primary discussion channel and keeping contact links current. No other navigation or social links were modified and no functional changes were introduced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->